### PR TITLE
Only skip first char of extracted filename if it's a slash.

### DIFF
--- a/src/formats/zip.zig
+++ b/src/formats/zip.zig
@@ -706,7 +706,7 @@ pub fn Parser(comptime Reader: type) type {
 
                     if (last_pos + 1 == hdr.filename_len) continue :extract;
 
-                    break :blk hdr.filename[last_pos + 1 ..];
+                    break :blk if (hdr.filename[last_pos] == '/') hdr.filename[last_pos + 1 ..] else hdr.filename[last_pos..];
                 };
 
                 if (std.fs.path.dirnamePosix(new_filename)) |dirname| {


### PR DESCRIPTION
I was extracting from a zip file which doesn't have `/` at the beginning of its file entries, so the extracted files were getting the first letter chopped off. I don't know if this also happens with tar files?